### PR TITLE
Add alpn identifier.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod session;
 
 pub use crate::aead::ChaCha8PacketKey;
 pub use crate::keylog::{KeyLog, KeyLogFile};
-pub use crate::session::{NoiseConfig, NoiseSession};
+pub use crate::session::{NoiseConfig, NoiseClientConfig, NoiseServerConfig, NoiseSession};
 pub use ed25519_dalek::{Keypair, PublicKey, SecretKey};
 
 // https://github.com/quicwg/base-drafts/wiki/QUIC-Versions


### PR DESCRIPTION
Closes #2 

- [x] add handshake data struct containing alpn string
- [x] support multiple application protocols
- [x] return proper error codes as specified in the quic-tls spec